### PR TITLE
Add endpoint for get transaction with the daemon rpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 anyhow = "1"
-async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 fixed-hash = "0.7"
 hex = "0.4"

--- a/README.md
+++ b/README.md
@@ -5,3 +5,24 @@
 Monero daemon and wallet RPC.
 
 License: MIT OR Apache-2.0
+
+## Example with tokio::test
+
+```
+#[tokio::test]
+async fn monero_daemon_transactions_test() {
+    let tx_id = "7c50844eced8ab78a8f26a126fbc1f731134e0ae3e6f9ba0f205f98c1426ff60".to_string();
+    let daemon_client = RpcClient::new("http://node.monerooutreach.org:18081".to_string());
+    let daemon = daemon_client.daemon_rpc();
+    let mut fixed_hash: [u8; 32] = [0; 32];
+    hex::decode_to_slice(tx_id, &mut fixed_hash).unwrap();
+    let tx = daemon
+        .get_transactions(vec![fixed_hash.into()], Some(true), Some(true))
+        .await;
+    println!("tx {:?}", tx);
+    println!(
+        "unlock time: {:?}",
+        serde_json::from_str::<JsonTransaction>(&tx.unwrap().txs_as_json.unwrap()[0])
+    );
+}
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,24 +55,14 @@ impl From<RpcParams> for Params {
     }
 }
 
-#[async_trait]
-trait JsonRpcCaller: Debug + Send + Sync + 'static {
-    async fn call(
-        &self,
-        method: &'static str,
-        params: RpcParams,
-    ) -> anyhow::Result<jsonrpc_core::Result<Value>>;
-}
-
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct RemoteCaller {
     http_client: reqwest::Client,
     addr: String,
 }
 
-#[async_trait]
-impl JsonRpcCaller for RemoteCaller {
-    async fn call(
+impl RemoteCaller {
+    async fn json_rpc_call(
         &self,
         method: &'static str,
         params: RpcParams,
@@ -103,18 +93,58 @@ impl JsonRpcCaller for RemoteCaller {
 
         Ok(v)
     }
+
+    async fn daemon_rpc_call<T>(&self, method: &'static str, params: RpcParams) -> anyhow::Result<T>
+    where
+        T: for<'de> Deserialize<'de> + Send + 'static + Debug,
+    {
+        let client = self.http_client.clone();
+        let uri = format!("{}/{}", &self.addr, method);
+
+        let json_params: jsonrpc_core::types::params::Params = params.into();
+
+        trace!(
+            "Sending daemon RPC call: {:?}, with params {:?}",
+            method,
+            json_params
+        );
+
+        let rsp = client
+            .post(uri)
+            .json(&json_params)
+            .send()
+            .await?
+            .json::<T>()
+            .await?;
+
+        trace!("Received daemon RPC response: {:?}", rsp);
+
+        Ok(rsp)
+    }
 }
 
 #[derive(Clone, Debug)]
-struct CallerWrapper(Arc<dyn JsonRpcCaller>);
+struct CallerWrapper(Arc<RemoteCaller>);
 
 impl CallerWrapper {
     async fn request<T>(&self, method: &'static str, params: RpcParams) -> anyhow::Result<T>
     where
         T: for<'de> Deserialize<'de> + Send + 'static,
     {
-        let c = self.0.call(method, params);
+        let c = self.0.json_rpc_call(method, params);
         Ok(serde_json::from_value(c.await??)?)
+    }
+
+    async fn daemon_rpc_request<T>(
+        &self,
+        method: &'static str,
+        params: RpcParams,
+    ) -> anyhow::Result<T>
+    where
+        T: for<'de> Deserialize<'de> + Send + 'static + Debug,
+    {
+        let c = self.0.daemon_rpc_call(method, params).await?;
+        Ok(serde_json::from_value(c)?)
     }
 }
 
@@ -138,6 +168,12 @@ impl RpcClient {
     pub fn daemon(self) -> DaemonClient {
         let Self { inner } = self;
         DaemonClient { inner }
+    }
+
+    /// Create a daemon rpc client
+    pub fn daemon_rpc(self) -> DaemonRpcClient {
+        let Self { inner } = self;
+        DaemonRpcClient { inner }
     }
 
     /// Create a wallet client.
@@ -285,6 +321,36 @@ impl DaemonClient {
     /// Enable additional functions for regtest mode
     pub fn regtest(self) -> RegtestDaemonClient {
         RegtestDaemonClient(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DaemonRpcClient {
+    inner: CallerWrapper,
+}
+
+impl DaemonRpcClient {
+    pub async fn get_transactions(
+        &self,
+        txs_hashes: Vec<CryptoNoteHash>,
+        decode_as_json: Option<bool>,
+        prune: Option<bool>,
+    ) -> anyhow::Result<TransactionsResponse> {
+        let params = empty()
+            .chain(once((
+                "txs_hashes",
+                txs_hashes
+                    .into_iter()
+                    .map(|s| HashString(s).to_string())
+                    .collect::<Vec<_>>()
+                    .into(),
+            )))
+            .chain(decode_as_json.map(|v| ("decode_as_json", v.into())))
+            .chain(prune.map(|v| ("prune", v.into())));
+        Ok(self
+            .inner
+            .daemon_rpc_request::<TransactionsResponse>("get_transactions", RpcParams::map(params))
+            .await?)
     }
 }
 
@@ -710,7 +776,7 @@ impl WalletClient {
         let rsp = match self
             .inner
             .0
-            .call("get_transfer_by_txid", RpcParams::map(params))
+            .json_rpc_call("get_transfer_by_txid", RpcParams::map(params))
             .await?
         {
             Ok(v) => serde_json::from_value::<Rsp>(v)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ mod models;
 
 pub use self::{models::*, util::*};
 
-use async_trait::async_trait;
 use jsonrpc_core::types::{Id, *};
 use monero::{cryptonote::hash::Hash as CryptoNoteHash, util::address::PaymentId, Address};
 use serde::{de::IgnoredAny, Deserialize, Deserializer, Serialize, Serializer};

--- a/src/models.rs
+++ b/src/models.rs
@@ -103,6 +103,38 @@ pub struct BlockHeaderResponse {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TransactionsResponse {
+    pub credits: u64,
+    pub top_hash: String,
+    pub status: String,
+    pub missed_tx: Option<Vec<HashString<CryptoNoteHash>>>,
+    pub txs: Option<Vec<Transaction>>,
+    pub txs_as_hex: Option<Vec<String>>,
+    pub txs_as_json: Option<Vec<String>>, // needs to be parsed as JsonTransaction, but is received as a string
+    pub untrusted: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Transaction {
+    pub as_hex: String,
+    pub as_json: Option<String>, // needs to be parsed as JsonTransaction, but is received as a string
+    pub block_height: u64,
+    pub block_timestamp: u64,
+    pub double_spend_seen: bool,
+    pub in_pool: bool,
+    pub output_indices: Vec<u64>,
+    pub tx_hash: HashString<CryptoNoteHash>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JsonTransaction {
+    pub version: u64,
+    pub unlock_time: u64,
+    // TODO: these fields are skipped for now, their content changes often from hardfork to hardfork
+    // vin, vout, extra, rct_signatures, rct_sig_prunable
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SubaddressBalanceData {
     pub address: Address,
     pub address_index: u64,


### PR DESCRIPTION
Creates a new client type `DaemonRpcClient` to interface with the daemon's raw rpc endpoints. The client is slightly refactored to cater to this new client that does not use JsonRpc.

The `get_transactions` method returns a `TransactionResponse` struct. This struct can then be further deserialized to access the hex or json encoded Transaction data.

Add an example to the README for the new endpoint.