### PR TITLE
Add endpoints for opening wallets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 
 #[macro_use]
 mod util;
-#[macro_use]
 mod models;
 
 pub use self::{models::*, util::*};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,6 +383,22 @@ impl WalletClient {
             .await
     }
 
+    /// Create a new wallet
+    pub async fn create_wallet(
+        &self,
+        filename: String,
+        password: Option<String>,
+        language: String,
+    ) -> anyhow::Result<()> {
+        let params = empty()
+            .chain(once(("filename", filename.into())))
+            .chain(password.map(|v| ("password", v.into())))
+            .chain(once(("language", language.into())));
+        self.inner
+            .request("create_wallet", RpcParams::map(params))
+            .await
+    }
+
     /// Opens an existing wallet file
     pub async fn open_wallet(
         &self,

--- a/src/models.rs
+++ b/src/models.rs
@@ -172,7 +172,7 @@ pub struct WalletCreation {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct WalletOpen {}
+pub struct WalletOpen;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AddressData {

--- a/src/models.rs
+++ b/src/models.rs
@@ -166,6 +166,15 @@ pub struct Payment {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WalletCreation {
+    pub address: Address,
+    pub info: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WalletOpen {}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AddressData {
     pub address: Address,
     pub addresses: Vec<SubaddressData>,
@@ -180,6 +189,17 @@ pub struct TransferOptions {
     pub unlock_time: Option<u64>,
     pub payment_id: Option<PaymentId>,
     pub do_not_relay: Option<bool>,
+}
+
+#[derive(Clone, Debug)]
+pub struct GenerateFromKeysArgs {
+    pub restore_height: Option<u64>,
+    pub filename: String,
+    pub address: Address,
+    pub spendkey: Option<monero::PrivateKey>,
+    pub viewkey: monero::PrivateKey,
+    pub password: String,
+    pub autosave_current: Option<bool>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
When the wallet rpc is run with `--wallet-dir`, it can manage multiple wallets at a time. This adds two endpoints, one to create a wallet from raw keys (`generate_from_keys`) and another to switch to an existing wallet (`open_wallet`).