### PR TITLE
chore: update shared workfow based on monero-rs

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,4 @@
-name: Create and publish release
+name: Create release
 
 on:
   pull_request:
@@ -9,31 +9,4 @@ jobs:
   create_release:
     name: Create from merged release branch
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Extract version from branch name
-        id: extract-version
-        shell: python
-        run: |
-          branch_name = "${{ github.event.pull_request.head.ref }}"
-          version = branch_name.split("/")[1]
-
-          print(f"::set-output name=version::{version}")
-
-      - name: Extract changelog section for release
-        id: changelog
-        uses: coditory/changelog-parser@v1
-        with:
-          version: ${{ steps.extract-version.outputs.version }}
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: ${{ steps.extract-version.outputs.version }}
-          tag_name: ${{ format('v{0}', steps.extract-version.outputs.version) }}
-          draft: false
-          prerelease: false
-          body: ${{ steps.changelog.outputs.description }}
-          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+    uses: monero-rs/workflows/.github/workflows/create-release.yml@v2.0.1

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -4,61 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: The new version in major.minor.patch format.
+        description: 'The new version in major.minor.patch format.'
         required: true
 
 jobs:
   draft-new-release:
     name: Draft a new release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Create release branch
-        run: git checkout -b release/${{ github.event.inputs.version }}
-
-      - name: Update changelog
-        uses: thomaseizinger/keep-a-changelog-new-release@1.3.0
-        with:
-          tag: ${{ format('v{0}', github.event.inputs.version) }}
-          changelogPath: CHANGELOG.md
-
-      - name: Bump version in Cargo.toml
-        uses: thomaseizinger/set-crate-version@1.0.0
-        with:
-          version: ${{ github.event.inputs.version }}
-          manifest: Cargo.toml
-
-      - name: Format CHANGELOG
-        run: |
-          curl -fsSL https://dprint.dev/install.sh | sh
-          /home/runner/.dprint/bin/dprint fmt CHANGELOG.md
-
-      - name: Add & Commit
-        id: make-commit
-        uses: EndBug/add-and-commit@v7.4.0
-        with:
-          message: Prepare release ${{ github.event.inputs.version }}
-          branch: release/${{ github.event.inputs.version }}
-          default_author: github_actions
-          pull: 'NO-PULL'
-          push: false
-
-      - name: Push new branch
-        run: git push origin release/${{ github.event.inputs.version }} --force
-
-      - name: Create pull request
-        uses: thomaseizinger/create-pull-request@1.2.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          head: release/${{ github.event.inputs.version }}
-          base: main
-          title: Release version ${{ github.event.inputs.version }}
-          body: |
-            Hi @${{ github.actor }}!
-
-            This PR was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
-            I've updated the changelog and bumped the versions in the manifest files in this commit: ${{ steps.make-commit.outputs.commit_sha }}.
-
-            Merging this PR will create a GitHub release and may update the library/binary on crates.io!
-
+    uses: monero-rs/workflows/.github/workflows/draft-new-release.yml@v2.0.1
+    with:
+      version: ${{ github.event.inputs.version }}

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ async fn monero_daemon_transactions_test() {
 }
 ```
 
-## Release Notes
+## Releases and Changelog
 
-See [CHANGELOG.md](CHANGELOG.md).
+See [CHANGELOG.md](CHANGELOG.md) and [RELEASING.md](RELEASING.md).
 
 ## Licensing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,11 @@
+# Releasing
+
+Releases of this crate are fairly automated.
+
+To create a new release:
+
+1. Make sure `CHANGELOG.md` is up-to-date and contain all modifications under the `[Unreleased]` section.
+2. Trigger [this](https://github.com/monero-ecosystem/monero-rpc-rs/actions/workflows/draft-new-release.yml) workflow with the desired version number.
+3. Merge the resulting PR (watch your notifications).
+
+The `[Unreleased]` section of `CHANGELOG.md` must contain all the changes that will be documented for the release.


### PR DESCRIPTION
Fix #38 

Reuse the work done in monero-rs. This PR should close some dependabot Actions update.