### PR TITLE
chore: update monero to version 0.17.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ fixed-hash = "0.7"
 hex = "0.4"
 http = "0.2"
 jsonrpc-core = "18"
-monero = { version = "0.16", features = ["serde_support"] }
+monero = { version = "0.17", features = ["serde"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Bump monero-rs version to latest release `0.17.0`. This will allow to use the `Amount` with `serde`.