### PR TITLE
chore: update test containers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,10 +34,14 @@ jobs:
           toolchain: stable
           override: true
       - name: Compose docker services
-        run: sudo apt-get install -y docker-compose && cd tests && docker-compose up -d && cd ..
+        run: |
+          sudo apt-get install -y docker-compose
+          cd tests
+          docker-compose up -d
+          cd ..
       - uses: actions-rs/cargo@v1
-      - name: Test
-        run: cargo test
+        with:
+          command: test
 
   fmt:
     name: Rustfmt

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,21 +1,19 @@
 version: "3.7"
 services:
     monerod:
-        image: ghcr.io/farcaster-project/containers/monerod:0.17.2.3
+        image: ghcr.io/farcaster-project/containers/monerod:0.17.3.2
         environment:
             NETWORK: regtest
-            MONEROD_RPC_PORT: 18081
             OFFLINE: --offline
             DIFFICULTY: 1
         ports:
             - 18081:18081
     monero-wallet-rpc:
-        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.2.3
+        image: ghcr.io/farcaster-project/containers/monero-wallet-rpc:0.17.3.2
         environment:
-            MONEROD_ADDRESS: monerod:18081
+            MONERO_DAEMON_ADDRESS: monerod:18081
             WALLET_RPC_PORT: 18083
         depends_on:
             - "monerod"
         ports:
             - 18083:18083
-


### PR DESCRIPTION
Use the latest version of monerod and wallet-rpc. See #48 for later improvements.