### PR TITLE
chore: bump shared workflows to 2.0.2

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,4 +9,4 @@ jobs:
   create_release:
     name: Create from merged release branch
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
-    uses: monero-rs/workflows/.github/workflows/create-release.yml@v2.0.1
+    uses: monero-rs/workflows/.github/workflows/create-release.yml@v2.0.2

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   draft-new-release:
     name: Draft a new release
-    uses: monero-rs/workflows/.github/workflows/draft-new-release.yml@v2.0.1
+    uses: monero-rs/workflows/.github/workflows/draft-new-release.yml@v2.0.2
     with:
       version: ${{ github.event.inputs.version }}
+      base_branch: 'master'


### PR DESCRIPTION
Bump to 2.0.2 to be able to configure the base branch as 'master' instead of 'main'.