### PR TITLE
docs(readme): add instructions on how to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ async fn monero_daemon_transactions_test() {
 }
 ```
 
+## Testing
+
+First, you'll need `docker` and `docker-compose` to run the RPC integration tests in case you don't want to run `monerod` and `monero-wallet-rpc` on your own.
+
+If you have the docker stack installed, go to the `tests` folder and run `docker-compose up`. Note that the daemon will run on port `18081` and `monero-wallet-rpc` will run on port `18083`.
+
+After that, just run `cargo test` as you normally would.
+
+Also, you can run `docker-compose down` to stop and remove the two containers started by `docker-compose up`.
+
 ## Releases and Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) and [RELEASING.md](RELEASING.md).


### PR DESCRIPTION
Just adds a small section on the readme on how to run the tests, even though it is pretty straighforward.