### PR TITLE
Util: Remove unused lifetime arg from impl Serialize for HashString

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -61,7 +61,7 @@ where
     }
 }
 
-impl<'a, T> Serialize for HashString<T>
+impl<T> Serialize for HashString<T>
 where
     T: HashType,
 {


### PR DESCRIPTION
This fixes a clippy finding:

```
error: this lifetime isn't used in the impl
  --> src/util.rs:64:6
   |
64 | impl<'a, T> Serialize for HashString<T>
   |      ^^
   |
```