### PR TITLE
refactor(models)!: remove duplicated SubAddressIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `SubAddressIndex` from `src/models.rs` ([#55](https://github.com/monero-ecosystem/monero-rpc-rs/pull/55))
+
+### Changed
+
+- Change any use of `SubAddressIndex` to `SubaddressIndex` ([#55](https://github.com/monero-ecosystem/monero-rpc-rs/pull/55))
+
 ## [0.1.0] - 2022-06-29
 
 ### Added

--- a/src/models.rs
+++ b/src/models.rs
@@ -263,15 +263,9 @@ pub struct IncomingTransfer {
     pub global_index: u64,
     pub key_image: Option<String>,
     pub spent: bool,
-    pub subaddr_index: SubAddressIndex,
+    pub subaddr_index: SubaddressIndex,
     pub tx_hash: HashString<CryptoNoteHash>,
     pub tx_size: Option<u64>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SubAddressIndex {
-    pub major: u64,
-    pub minor: u64,
 }
 
 /// Argument type of wallet `sweep_all`.


### PR DESCRIPTION
Closes #42

Decided to remove `SubAddressIndex` instead of `SubaddressIndex` because there are other structs in `models.rs` whose name start with `Subaddress` (with lowercase `a`).

No farcaster project used  `SubAddressIndex`, but I marked the commit with a `!` (as per https://www.conventionalcommits.org/en/v1.0.0/) to indicate that this is possibly a breaking change (in case anyone imported  it in their projects).