### PR TITLE
test(models): add basic tests for models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add tests for types implementing `HashType` in `utils.rs` ([#59](https://github.com/monero-ecosystem/monero-rpc-rs/pull/59))
 - Add tests for `HashString`'s implementation of the traits `Debug`, `Serialize`, and `Deserialize`, in `utils.rs` ([#59](https://github.com/monero-ecosystem/monero-rpc-rs/pull/59))
+- Add tests for `models.rs` ([#63](https://github.com/monero-ecosystem/monero-rpc-rs/pull/63))
 
 ### Removed
 


### PR DESCRIPTION
This adds basic tests for 

They may seem redundant since there wasn't much to be tested, but having unit tests to make sure things work as expected and no "innocent" change mess up with things, is always good.