### PR TITLE
feat(crate): re-export `monero-rs` since it is a dependency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@
 
 #![forbid(unsafe_code)]
 
+pub use monero;
+
 #[macro_use]
 mod util;
 mod models;


### PR DESCRIPTION
Closes #66 