### PR TITLE
Disable chrono default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Disable chrono default features by @silverpill ([#87](https://github.com/monero-ecosystem/monero-rpc-rs/pull/87))
+
 ## [0.2.0] - 2022-07-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "RPC client for Monero daemon and wallet"
 
 [dependencies]
 anyhow = "1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
 fixed-hash = "0.8"
 hex = "0.4"
 http = "0.2"


### PR DESCRIPTION
This removes outdated `time` crate from the dependency tree